### PR TITLE
HG-22 Unable to summarize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "isomorphic-ws": "^5.0.0",
         "jose": "^4.14.4",
         "json-bigint": "^1.0.0",
+        "rfc6902": "^5.1.1",
         "ts-invariant": "^0.10.3",
         "tweetnacl": "^1.0.3",
         "utf-8-validate": "^6.0.3"
@@ -903,6 +904,11 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/rfc6902": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.1.1.tgz",
+      "integrity": "sha512-8rKImbe8GTXJ7cl9v+sF3U0WQ9aaSBn4fEcGP1VJakWN335ufj75ctvWXEhrzecGRxXpY6pEFbcdWzesjV7bFg=="
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -1610,6 +1616,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "rfc6902": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/rfc6902/-/rfc6902-5.1.1.tgz",
+      "integrity": "sha512-8rKImbe8GTXJ7cl9v+sF3U0WQ9aaSBn4fEcGP1VJakWN335ufj75ctvWXEhrzecGRxXpY6pEFbcdWzesjV7bFg=="
     },
     "safer-buffer": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "isomorphic-ws": "^5.0.0",
     "jose": "^4.14.4",
     "json-bigint": "^1.0.0",
+    "rfc6902": "^5.1.1",
     "ts-invariant": "^0.10.3",
     "tweetnacl": "^1.0.3",
     "utf-8-validate": "^6.0.3"

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,5 +1,7 @@
 import fetch from 'isomorphic-fetch'
 import WebSocket from 'isomorphic-ws'
+import { createPatch } from 'rfc6902';
+import { AddOperation, RemoveOperation, ReplaceOperation } from 'rfc6902/diff';
 import {createClient, Client as SubscriptionClient} from '../../graphql-ws/src'
 import {
   Network,
@@ -8,8 +10,10 @@ import {
   Client,
   FlexibleRequestBody,
   SubscriptionHandlers,
+  PatchedSubscriptionHandlers,
+  PatchOperation,
 } from '../types'
-import {formatRequestBody} from './utils'
+import { formatRequestBody, resolveJsonPointer } from './utils'
 
 // generate types
 //https://github.com/evanw/esbuild/issues/95#issuecomment-1007485134
@@ -77,5 +81,31 @@ export default class HgraphClient implements Client {
   ) {
     const body = formatRequestBody(flexibleRequestBody)
     return this.subscriptionClient.subscribe(body, handlers)
+  }
+
+  patchedSubscribe(
+    flexibleRequestBody: FlexibleRequestBody,
+    handlers: PatchedSubscriptionHandlers
+  ) {
+    let prevData = null;
+    const body = formatRequestBody(flexibleRequestBody)
+    return this.subscriptionClient.subscribe(body, {
+      ...handlers,
+      next: (data) => {
+        let patches: PatchOperation[] = [];
+        if (prevData) {
+          patches = createPatch(prevData, data)
+            .map((operation: AddOperation | ReplaceOperation | RemoveOperation) => {
+              return {
+                ...operation,
+                //add value to remove operation
+                value: operation.op == 'remove' ? resolveJsonPointer(prevData, operation.path) : operation.value
+              }
+            });
+        }
+        prevData = data;
+        handlers.next(data, patches);
+      },
+    })
   }
 }

--- a/src/client/utils/index.ts
+++ b/src/client/utils/index.ts
@@ -1,1 +1,2 @@
 export {default as formatRequestBody} from './formatRequestBody'
+export {default as resolveJsonPointer} from './resolveJsonPointer'

--- a/src/client/utils/resolveJsonPointer.ts
+++ b/src/client/utils/resolveJsonPointer.ts
@@ -1,0 +1,13 @@
+// https://datatracker.ietf.org/doc/html/rfc6901
+export default function resolveJsonPointer(instance: any, pointer: string) {
+  let result = instance;
+  const [, ...tokens] = pointer.split("/");
+  const parts = tokens.map(token => token
+    .replace(/~1/g, "/")
+    .replace(/~0/g, "~")
+  );
+  for (const part of parts) {
+    result = result && result[part];
+  }
+  return result;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,10 @@ export interface Client {
     flexibleRequestBody: FlexibleRequestBody,
     handlers: SubscriptionHandlers
   ) => () => void
+  patchedSubscribe: (
+    flexibleRequestBody: FlexibleRequestBody,
+    handlers: PatchedSubscriptionHandlers
+  ) => () => void
 }
 
 export default class HgraphClient implements Client {
@@ -70,6 +74,10 @@ export default class HgraphClient implements Client {
   subscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: SubscriptionHandlers
+  ) => () => void
+  patchedSubscribe: (
+    flexibleRequestBody: FlexibleRequestBody,
+    handlers: PatchedSubscriptionHandlers
   ) => () => void
 }
 
@@ -97,6 +105,27 @@ export interface GraphQLRequestPayload extends RequestBody {
  */
 
 declare function stripShardRealm(accountId: string): number
+
+/*
+ * JSON Patch Operation
+ */
+export interface PatchOperation {
+  op: 'add' | 'remove' | 'replace'
+  path: string // https://datatracker.ietf.org/doc/html/rfc6901
+  value: any
+}
+
+/*
+ * Responses for patchedSubscribe
+ */
+// https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md 
+// https://datatracker.ietf.org/doc/html/rfc6902
+export interface PatchedSubscriptionHandlers {
+  next: <TData,TExtension>(data: ExecutionResult<TData,TExtension>, patches: PatchOperation[]) => void
+  error: (err: GraphQLError[]) => void
+  complete: () => void
+}
+
 
 /*
  * Responses


### PR DESCRIPTION
A new patchedSubscribe method has been added, which is an extension of the subscribe method with the addition of patches displaying changes in updated data. Patches are operations from [RFC6902](https://datatracker.ietf.org/doc/html/rfc6902 ), specifically "add", "remove", "replace". 
Package [rfc6902](https://www.npmjs.com/package/rfc6902) was used to calculate the difference between old and new data.
This approach is universal and allows you to process many use cases when it is necessary to understand what happened to the updated data, for example, when someone transfers rights to NFT or revokes them. The following is a minimal example demonstrating it case using patchedSubscribe function:

```ts

import Client, { Network, Environment } from '@hgraph.io/sdk';

const hg = new Client({
  network: Network.HederaTestnet,
  environment: Environment.Production,
});

hg.patchedSubscribe({
  query: `
  subscription GetNFTs($spender: bigint!) {
    nft(where: { spender: { _eq: $spender } }) {
      token_id
      serial_number
    }
  }`,
  variables: {
    spender: "4398564"
  }
}, {
  next: (data, patches) => {
    // data - current nfts
    for (const patch of patches) {
      if (patch.op == 'add') {
        console.log("New NFT:", patch.value);
      }
      else if (patch.op == 'remove') {
        console.log("Removed NFT:", patch.value);
      }
    }
  },
  error: (err) => {
    console.error(err);
  },
  complete: () => {
    console.log("Complete");
  }
})
```