### PR TITLE
HG-122 Review the sdk feature request and implement solution

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -81,7 +81,7 @@ export default class HgraphClient implements Client {
     observable.unsubscribe()
   }
   
-  removeAllSubscription() {
+  removeAllSubscriptions() {
     this.getSubscribtions().forEach(observable=> observable.unsubscribe())
   }
 
@@ -99,7 +99,7 @@ export default class HgraphClient implements Client {
       handlers,
       unsubscribe: null
     }
-    
+
     const cleanUpSubscription = (observable: ObservableSubscription) => {
       this.subscriptions = this.subscriptions.filter(subscription => subscription != observable)
       observableSubscription.unsubscribe = () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,7 +60,7 @@ export interface Client {
   headers: Record<string, string>
   subscriptionClient: SubscriptionClient
   removeSubscription: (subscription: ObservableSubscription) => void
-  removeAllSubscription: () => void
+  removeAllSubscriptions: () => void
   getSubscribtions: () => ObservableSubscription[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,
@@ -83,7 +83,7 @@ export default class HgraphClient implements Client {
   subscriptionClient: SubscriptionClient
   private subscriptions: ObservableSubscription[]
   removeSubscription: (subscription: ObservableSubscription) => void
-  removeAllSubscription: () => void
+  removeAllSubscriptions: () => void
   getSubscribtions: () => ObservableSubscription[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,6 +59,11 @@ export interface Client {
   endpoint: string
   headers: Record<string, string>
   subscriptionClient: SubscriptionClient
+
+  removeSubscription: (subscription: SubscriptionObservable) => void
+  removeAllSubscription: () => void
+  getSubscribtions: () => SubscriptionObservable[]
+
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,
     abortSignal?: AbortSignal
@@ -66,11 +71,11 @@ export interface Client {
   subscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: SubscriptionHandlers
-  ) => () => void
+  ) => SubscriptionObservable
   patchedSubscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: PatchedSubscriptionHandlers
-  ) => () => void
+  ) => SubscriptionObservable
 }
 
 export default class HgraphClient implements Client {
@@ -78,6 +83,10 @@ export default class HgraphClient implements Client {
   endpoint: string
   headers: Record<string, string>
   subscriptionClient: SubscriptionClient
+  private subscriptions: SubscriptionObservable[]
+  removeSubscription: (subscription: SubscriptionObservable) => void
+  removeAllSubscription: () => void
+  getSubscribtions: () => SubscriptionObservable[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,
     abortSignal?: AbortSignal
@@ -85,11 +94,11 @@ export default class HgraphClient implements Client {
   subscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: SubscriptionHandlers
-  ) => () => void
+  ) => SubscriptionObservable
   patchedSubscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: PatchedSubscriptionHandlers
-  ) => () => void
+  ) => SubscriptionObservable
 }
 
 /*
@@ -112,6 +121,12 @@ export interface ContractQueryEventsParams {
   limit?: number;
   offset?: number;
   order?: Order;
+}
+
+
+export interface SubscriptionObservable {
+  readonly handlers: SubscriptionHandlers;
+  unsubscribe: () => void;
 }
 
 export declare class HgraphContract {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,11 +59,9 @@ export interface Client {
   endpoint: string
   headers: Record<string, string>
   subscriptionClient: SubscriptionClient
-
-  removeSubscription: (subscription: SubscriptionObservable) => void
+  removeSubscription: (subscription: ObservableSubscription) => void
   removeAllSubscription: () => void
-  getSubscribtions: () => SubscriptionObservable[]
-
+  getSubscribtions: () => ObservableSubscription[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,
     abortSignal?: AbortSignal
@@ -71,11 +69,11 @@ export interface Client {
   subscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: SubscriptionHandlers
-  ) => SubscriptionObservable
+  ) => ObservableSubscription
   patchedSubscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: PatchedSubscriptionHandlers
-  ) => SubscriptionObservable
+  ) => ObservableSubscription
 }
 
 export default class HgraphClient implements Client {
@@ -83,10 +81,10 @@ export default class HgraphClient implements Client {
   endpoint: string
   headers: Record<string, string>
   subscriptionClient: SubscriptionClient
-  private subscriptions: SubscriptionObservable[]
-  removeSubscription: (subscription: SubscriptionObservable) => void
+  private subscriptions: ObservableSubscription[]
+  removeSubscription: (subscription: ObservableSubscription) => void
   removeAllSubscription: () => void
-  getSubscribtions: () => SubscriptionObservable[]
+  getSubscribtions: () => ObservableSubscription[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,
     abortSignal?: AbortSignal
@@ -94,11 +92,11 @@ export default class HgraphClient implements Client {
   subscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: SubscriptionHandlers
-  ) => SubscriptionObservable
+  ) => ObservableSubscription
   patchedSubscribe: (
     flexibleRequestBody: FlexibleRequestBody,
     handlers: PatchedSubscriptionHandlers
-  ) => SubscriptionObservable
+  ) => ObservableSubscription
 }
 
 /*
@@ -124,7 +122,7 @@ export interface ContractQueryEventsParams {
 }
 
 
-export interface SubscriptionObservable {
+export interface ObservableSubscription {
   readonly handlers: SubscriptionHandlers;
   unsubscribe: () => void;
 }


### PR DESCRIPTION
Subscription management for `HgraphClient` was introduced. All active subscriptions and their lifecycle control are now encapsulated inside the client, making it easier to interact with them. The `subscribe` and `patchedSubscribe` methods now return an immutable object of type `ObservableSubscription`, which is itself a subscription identifier and also contains an `unsubscribe` method.
In addition, new methods have been added to the client:
```ts
removeSubscription: (subscription: ObservableSubscription) => void
removeAllSubscriptions: () => void
getSubscribtions: () => ObservableSubscription[]
```

This approach is similar to [channel management in Supabase](https://supabase.com/docs/reference/javascript/subscribe).
Internally, the client sets proxy handlers for subscriptions, so any finalizing events occurring in a subscription (`error`, `complete`) cause that subscription to be cleared in the client. 

An example of working with the new approach to subscription management.
Subscription creation is unchanged, but an object of type `ObservableSubscription` is returned:

```ts
import Client, { Network, Environment, ObservableSubscription } from '@hgraph.io/sdk';

const hg = new Client({
  network: Network.HederaMainnet,
  environment: Environment.Production,
});

const transactionSubscription: ObservableSubscription = hg.subscribe({
  query: `
  subscription LastTransaction {
    transaction(limit: 1, order_by: {consensus_timestamp: desc}) {
      id
      consensus_timestamp
    }
  }`
}, {
  next: (data)=> {
    console.log(data);
  },
  error: (errors) => {
    console.error('LastTransaction subscription closed with errors:', errors);
  },
  complete: () => {
    console.log("LastTransaction subscription complete");
  }
});
```

Unsubscribe active subscription:
```ts
transactionSubscription.unsubscribe();
```
or
```ts
hg.removeSubscription(transactionSubscription);
```
> An exception will be raised when attempting to unsubscribe an already completed subscription to prevent unwanted side effects

Unsubscribe all active subscriptions of the client:
```ts
hg.removeAllSubscriptions();
```
> when unsubscribing by any method, the `complete` subscription handler is called.

Retrieves all active subscriptions of the client:
```ts
const subscriptions: ObservableSubscription[] = hg.getSubscriptions();
```