### PR TITLE
Fix subscription accessor naming

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -88,12 +88,19 @@ export default class HgraphClient implements Client {
   }
 
   removeAllSubscriptions() {
-    this.getSubscribtions().forEach((observable) => observable.unsubscribe())
+    this.getSubscriptions().forEach((observable) => observable.unsubscribe())
   }
 
-  getSubscribtions() {
+  getSubscriptions() {
     //copy of original array
     return [...this.subscriptions]
+  }
+
+  /**
+   * @deprecated Use {@link getSubscriptions} instead.
+   */
+  getSubscribtions() {
+    return this.getSubscriptions()
   }
 
   subscribe(

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,6 +69,10 @@ export interface Client {
   subscriptionClient: SubscriptionClient
   removeSubscription: (subscription: ObservableSubscription) => void
   removeAllSubscriptions: () => void
+  getSubscriptions: () => ObservableSubscription[]
+  /**
+   * @deprecated Use `getSubscriptions` instead.
+   */
   getSubscribtions: () => ObservableSubscription[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,
@@ -92,6 +96,10 @@ export default class HgraphClient implements Client {
   private subscriptions: ObservableSubscription[]
   removeSubscription: (subscription: ObservableSubscription) => void
   removeAllSubscriptions: () => void
+  getSubscriptions: () => ObservableSubscription[]
+  /**
+   * @deprecated Use `getSubscriptions` instead.
+   */
   getSubscribtions: () => ObservableSubscription[]
   query: <T>(
     flexibleRequestBody: FlexibleRequestBody,


### PR DESCRIPTION
## Summary
- rename `getSubscribtions` to `getSubscriptions`
- add deprecated wrapper for old method name
- update TypeScript types

## Testing
- `npm run build` *(fails: Could not resolve "../../graphql-ws/src")*

------
https://chatgpt.com/codex/tasks/task_b_685a2ec9ab8083279d4008286ed800d6