### PR TITLE
README: drop links to the archived template repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,31 +60,6 @@ const hgraph = new HgraphSDK({
   },
 });
 ```
-## Examples
-
-### Overview
-
-To help you get started quickly, we offer a collection of quick-start template repositories tailored for various development environments. These templates come pre-configured with essential settings and dependencies, allowing you to set up your project with minimal effort. By leveraging these templates, you can quickly integrate Hgraph into your project and begin building right away.
-
-### Available Templates
-
-Choose the template that best fits your development environment:
-
-**[Node →](https://github.com/hgraph-io/nodejs-template)**  
-Ideal for backend and server-side applications using Node.js.
-
-**[Browser →](https://github.com/hgraph-io/browser-template)**  
-Tailored for web applications running directly in the browser, enabling quick integration with Hgraph APIs.
-
-**[Next.js →](https://github.com/hgraph-io/nextjs-template)**  
-Optimized for full-stack and server-rendered applications using Next.js.
-
-**[React →](https://github.com/hgraph-io/react-template)**  
-For frontend projects using React, providing an easy setup for single-page applications.
-
-**[React Native →](https://github.com/hgraph-io/react-native-template)**  
-Suitable for mobile app development with React Native, allowing cross-platform development with Hgraph.
-
 ## Subscriptions
 
 Our [documentation](https://docs.hgraph.com/graphql-api/subscriptions) introduces the subscription capabilities in the Hgraph SDK, enabling developers to easily set up and manage real-time data streams with GraphQL. It provides guidance on using built-in methods to track data changes and efficiently handle subscription lifecycles.


### PR DESCRIPTION
The five quick-start template repos (`nodejs-template`, `browser-template`, `nextjs-template`, `react-template`, `react-native-template`) were archived today, together with `hedera-app`, `hedera-wallet`, and `hedera-stats`. The README's *Examples / Available Templates* section pointed exclusively at them, so this removes the section.

No other file in this repo references any of the archived repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ByPPR2cZLFVjVqS9annCmS