### PR TITLE
ci: test on Node 22 instead of EOL Node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - run: npm ci
       - run: npm test


### PR DESCRIPTION
Item 2 of hgraph-io/sdk#68.

## Change

One line in `.github/workflows/test.yml`:

```diff
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
```

Node 18 went end-of-life in April 2025, so `npm ci` and `npm test` have been running against an unsupported runtime. Node 22 is an LTS release supported through April 2027, and is the version the issue names.

`engines: { node: ">=18" }` in `package.json` is deliberately left alone. It declares what consumers may run; the workflow declares what the project tests on. Narrowing the supported range for consumers is a separate decision and is not part of this issue.

This is the only workflow in the repo and the only `node-version` pin in it:

```
$ git grep -n "node-version" -- .github/workflows
.github/workflows/test.yml:16:          node-version: 22
```

## Findings

None. No dead code was found and nothing was deleted; no check config was changed. The workflow already ran `npm ci` and `npm test`, so this raises the runtime under an existing gate rather than adding a new one.

## Check output

`npm test` (jest, the command the workflow gates on):

```
Test Suites: 20 passed, 20 total
Tests:       67 passed, 67 total
Snapshots:   0 total
Time:        11.909 s
Ran all test suites.
```

Coverage reported 100% across every `src` file except the two generated `.d.ts` type modules.

Honest caveat on where that run happened: no Node 22 toolchain was available on the machine this was prepared on, so the local run used Node 26.5.0, and `npm ci` needed `--ignore-scripts` because that machine cannot compile the `utf-8-validate` native addon (missing C++ headers, a local toolchain gap rather than a repo problem). Node 22 sits between the previously gated 18 and the locally verified 26.

The authoritative evidence is therefore this PR's own `Node.js CI` check, which runs the full `npm ci` and `npm test` on Node 22 on `ubuntu-latest`. Its result is posted as a comment below once it finishes; please do not merge on the strength of the local run alone.

## Not in scope

- Item 1 (`ws` at runtime scope) is handled by #67.
- Item 3 (the dev-scope advisory backlog, including the `@graphql-codegen/*` v5 pin that Node 18 forced) is downstream of this change. Re-running Dependabot after this merges is the step that tests whether the codegen major can now land.
- `actions/checkout@v3` and `actions/setup-node@v3` are older major versions, but bumping them is not what this issue asked for and is left for a run that names them.

Spec issue: https://github.com/hgraph-io/sdk/issues/68
